### PR TITLE
Form data header handling

### DIFF
--- a/Request/index.ts
+++ b/Request/index.ts
@@ -39,6 +39,8 @@ export namespace Request {
 		const r = is(request) ? request : create(request)
 		const contentType = r.header.contentType
 		let headers
+		// If what is being sent is multipart/formdata, its previous content-type header
+		// needs to be removed in order for the new form-data boundary to be set correctly.
 		if (contentType?.split(";")[0] == "multipart/form-data") {
 			const newHeader = Object.fromEntries(Object.entries(r.header).filter(k => k[0] != "contentType"))
 			headers = newHeader

--- a/Request/index.ts
+++ b/Request/index.ts
@@ -40,7 +40,8 @@ export namespace Request {
 		const contentType = r.header.contentType
 		let headers
 		if (contentType?.split(";")[0] == "multipart/form-data") {
-			headers = { ...r.header, contentType: undefined }
+			const newHeader = Object.fromEntries(Object.entries(r.header).filter(k => k[0] != "contentType"))
+			headers = newHeader
 		} else {
 			headers = r.header
 		}


### PR DESCRIPTION
We had a problem with an old "mulitpart/form-data" content-type header being kept with an old boundary value resulting in the body not being parsed correctly. So this is to avoid that.