### PR TITLE
Properties from Cloudflare-requests in Request.

### DIFF
--- a/Parser.ts
+++ b/Parser.ts
@@ -1,5 +1,9 @@
+import type { Request as CloudflareRequest } from "@cloudflare/workers-types"
+
 const parsers: {
-	[contentType: string]: ((request: globalThis.Request | globalThis.Response) => Promise<any>) | undefined
+	[contentType: string]:
+		| ((request: globalThis.Request | CloudflareRequest | globalThis.Response) => Promise<any>)
+		| undefined
 } = {}
 export function add(
 	parser: (request: globalThis.Request | globalThis.Response) => Promise<any>,
@@ -7,7 +11,7 @@ export function add(
 ): void {
 	contentType.forEach(t => (parsers[t] = parser))
 }
-export function parse(request: globalThis.Request | globalThis.Response): Promise<any> {
+export function parse(request: globalThis.Request | CloudflareRequest | globalThis.Response): Promise<any> {
 	const contentType = request.headers.get("Content-Type")
 	const type = contentType && contentType.split(";")
 	const parser = parsers[type?.[0] ?? "plain/text"]

--- a/Request/index.ts
+++ b/Request/index.ts
@@ -14,7 +14,7 @@ export interface Request {
 	readonly remote?: string
 	readonly header: Readonly<RequestHeader>
 	readonly body?: any | Promise<any>
-	readonly cloudflare?: CloudflareRequest["cf"]
+	readonly cloudflare?: Readonly<CloudflareRequest["cf"]>
 }
 
 export namespace Request {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.1.2",
 			"license": "MIT",
 			"devDependencies": {
+				"@cloudflare/workers-types": "^4.20230221.0",
 				"@types/isomorphic-fetch": "0.0.36",
 				"@types/jest": "^29.2.5",
 				"@typescript-eslint/eslint-plugin": "5.48.1",
@@ -673,6 +674,12 @@
 				"vfile-location": "^3.2.0",
 				"xtend": "^4.0.2"
 			}
+		},
+		"node_modules/@cloudflare/workers-types": {
+			"version": "4.20230221.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20230221.0.tgz",
+			"integrity": "sha512-Ge8csuFQMNv3hd8r85PFWv4KV6bHAtKoBaanTkjbbeJS+mizoiBn4OBva0CFQiGfRJklFSGd4OxuCuiK05kogg==",
+			"dev": true
 		},
 		"node_modules/@eslint/eslintrc": {
 			"version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"prettierx": "github:utily/prettierx#utily-20221229",
 		"rimraf": "^4.0.4",
 		"ts-jest": "^29.0.4",
-		"typescript": "^4.9.4"
+		"typescript": "^4.9.4",
+		"@cloudflare/workers-types": "^4.20230221.0"
 	}
 }


### PR DESCRIPTION
`http.from(...)` now also accepts a Request from Cloudflare, which includes some metadata that Cloudlflare adds.

If present, the data is attached to the returned `http.Requst` as an optional property called `cloudflare`.

This is what a metadata looks like: (This is the endpoint Miniflare uses.)
https://workers.cloudflare.com/cf.json
