### PR TITLE
Internal auth middleware no longer overwrites existing auth header if it exists

### DIFF
--- a/Client.ts
+++ b/Client.ts
@@ -26,7 +26,10 @@ export class Client<Error = never> {
 						? request
 						: {
 								...request,
-								header: { ...request.header, authorization: Authorization.serialize(this.authorization) },
+								header: {
+									...request.header,
+									...(!request.header.authorization && { authorization: Authorization.serialize(this.authorization) }),
+								},
 						  }
 				)
 			)

--- a/Client.ts
+++ b/Client.ts
@@ -28,7 +28,8 @@ export class Client<Error = never> {
 								...request,
 								header: {
 									...request.header,
-									...(!request.header.authorization && { authorization: Authorization.serialize(this.authorization) }),
+									...(!request.header.authorization &&
+										this.authorization && { authorization: Authorization.serialize(this.authorization) }),
 								},
 						  }
 				)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2398,10 +2398,11 @@
 			}
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",


### PR DESCRIPTION
These changes allow cloudly-http clients to send a one off request with different auth. 
This is needed to for example send login request with Basic auth to acquire a token that is then set to the client. 
Without these changes the Basic auth would have to be applied across the entire client for all requests even for requests where Basic auth is not wanted.